### PR TITLE
exclude `cv.email` attribute when returns `/curriculum/get`

### DIFF
--- a/endpoints/resources/curriculum/get.js
+++ b/endpoints/resources/curriculum/get.js
@@ -44,7 +44,7 @@ module.exports = async (req, res) => {
 		}
 	}
 
-	delete cv.email;
+	cv.email = undefined;
 	cv.lang = user.lang;
 
 	return res.status(200).json(fnBadwords.cleanObject(cv));


### PR DESCRIPTION
When the user access the CV page, an XHR request made possible to get the private email, for some reason the `delete cv.email` don't remove the email.

handle with Cv-Keep/cvkeep-backend#10